### PR TITLE
Add IntOrString custom type for VM IDs

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -51,32 +51,32 @@ type GetClusterResourcesResponse struct {
 
 // GetClusterResourcesData contains data of a cluster's resources from GetClusterResources
 type GetClusterResourcesData struct {
-	ID         string   `json:"id"`
-	Node       string   `json:"node"`
-	Status     string   `json:"status"`
-	Type       string   `json:"type"`
-	CPU        *float64 `json:"cpu"`
-	Disk       *int     `json:"disk"`
-	DiskRead   *int     `json:"diskread"`
-	DiskWrite  *int     `json:"diskwrite"`
-	MaxCPU     *int     `json:"maxcpu"`
-	MaxDisk    *int     `json:"maxdisk"`
-	MaxMem     *int     `json:"maxmem"`
-	Mem        *int     `json:"mem"`
-	Name       *string  `json:"name"`
-	NetIn      *int     `json:"netin"`
-	NetOut     *int     `json:"netout"`
-	Template   *int     `json:"template"`
-	Uptime     *int     `json:"uptime"`
-	VMID       *int     `json:"vmid"`
-	HAState    *string  `json:"hastate"`
-	CgroupMode *int     `json:"cgroup-mode"`
-	Level      *string  `json:"level"`
-	Content    *string  `json:"content"`
-	PluginType *string  `json:"plugintype"`
-	Shared     *int     `json:"shared"`
-	Storage    *string  `json:"storage"`
-	SDN        *string  `json:"sdn"`
+	ID         string       `json:"id"`
+	Node       string       `json:"node"`
+	Status     string       `json:"status"`
+	Type       string       `json:"type"`
+	CPU        *float64     `json:"cpu"`
+	Disk       *int         `json:"disk"`
+	DiskRead   *int         `json:"diskread"`
+	DiskWrite  *int         `json:"diskwrite"`
+	MaxCPU     *int         `json:"maxcpu"`
+	MaxDisk    *int         `json:"maxdisk"`
+	MaxMem     *int         `json:"maxmem"`
+	Mem        *int         `json:"mem"`
+	Name       *string      `json:"name"`
+	NetIn      *int         `json:"netin"`
+	NetOut     *int         `json:"netout"`
+	Template   *int         `json:"template"`
+	Uptime     *int         `json:"uptime"`
+	VMID       *IntOrString `json:"vmid"`
+	HAState    *string      `json:"hastate"`
+	CgroupMode *int         `json:"cgroup-mode"`
+	Level      *string      `json:"level"`
+	Content    *string      `json:"content"`
+	PluginType *string      `json:"plugintype"`
+	Shared     *int         `json:"shared"`
+	Storage    *string      `json:"storage"`
+	SDN        *string      `json:"sdn"`
 }
 
 // GetClusterResources makes a GET request to the /cluster/resources endpoint

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -20,6 +20,10 @@ func testFloat64(f float64) *float64 {
 	return &f
 }
 
+func testIntOrString(is IntOrString) *IntOrString {
+	return &is
+}
+
 func TestGetClusterResources(t *testing.T) {
 	mux, server, client := setup(t)
 	defer teardown(server)
@@ -53,7 +57,7 @@ func TestGetClusterResources(t *testing.T) {
 				Template:  testInt(0),
 				Type:      "qemu",
 				Uptime:    testInt(234806),
-				VMID:      testInt(101),
+				VMID:      testIntOrString("101"),
 			},
 			{
 				CgroupMode: testInt(2),

--- a/nodes.go
+++ b/nodes.go
@@ -26,7 +26,7 @@ type GetNodesData struct {
 	MaxMem         int     `json:"maxmem"`
 	Mem            int     `json:"mem"`
 	Node           string  `json:"node"`
-	SslFingerprint string  `json:"ssl_fingerprint"`
+	SSLFingerprint string  `json:"ssl_fingerprint"`
 	Status         string  `json:"status"`
 	Type           string  `json:"type"`
 	Uptime         int     `json:"uptime"`
@@ -62,12 +62,12 @@ type GetNodeStatusData struct {
 	CPUInfo       CPUInfo       `json:"cpuinfo"`
 	CurrentKernel CurrentKernel `json:"current-kernel"`
 	Idle          int           `json:"idle"`
-	Ksm           Ksm           `json:"ksm"`
+	KSM           KSM           `json:"ksm"`
 	Kversion      string        `json:"kversion"`
 	LoadAvg       []string      `json:"loadavg"`
 	Memory        Memory        `json:"memory"`
 	PveVersion    string        `json:"pveversion"`
-	RootFs        RootFs        `json:"rootfs"`
+	RootFs        RootFS        `json:"rootfs"`
 	Swap          Swap          `json:"swap"`
 	Uptime        int           `json:"uptime"`
 	Wait          float64       `json:"wait"`
@@ -129,21 +129,21 @@ type GetNodeQemuResponse struct {
 
 // GetNodeQemuData contains data of one VM from a GetNodeQemu response
 type GetNodeQemuData struct {
-	CPU       float64 `json:"cpu"`
-	Cpus      int     `json:"cpus"`
-	Disk      int     `json:"disk"`
-	DiskRead  int     `json:"diskread"`
-	DiskWrite int     `json:"diskwrite"`
-	MaxDisk   int     `json:"maxdisk"`
-	MaxMem    int     `json:"maxmem"`
-	Mem       int     `json:"mem"`
-	Name      string  `json:"name"`
-	NetIn     int     `json:"netin"`
-	NetOut    int     `json:"netout"`
-	Pid       int     `json:"pid"`
-	Status    string  `json:"status"`
-	Uptime    int     `json:"uptime"`
-	VMID      int     `json:"vmid"`
+	CPU       float64     `json:"cpu"`
+	CPUs      int         `json:"cpus"`
+	Disk      int         `json:"disk"`
+	DiskRead  int         `json:"diskread"`
+	DiskWrite int         `json:"diskwrite"`
+	MaxDisk   int         `json:"maxdisk"`
+	MaxMem    int         `json:"maxmem"`
+	Mem       int         `json:"mem"`
+	Name      string      `json:"name"`
+	NetIn     int         `json:"netin"`
+	NetOut    int         `json:"netout"`
+	PID       int         `json:"pid"`
+	Status    string      `json:"status"`
+	Uptime    int         `json:"uptime"`
+	VMID      IntOrString `json:"vmid"`
 }
 
 // GetNodeQemu makes a GET request to the /nodes/{node}/qemu endpoint
@@ -171,22 +171,22 @@ type GetNodeLxcResponse struct {
 
 // GetNodeLxcData contains data of one VM from a GetNodeLxc response
 type GetNodeLxcData struct {
-	CPU       float64 `json:"cpu"`
-	Cpus      int     `json:"cpus"`
-	Disk      int     `json:"disk"`
-	DiskRead  int     `json:"diskread"`
-	DiskWrite int     `json:"diskwrite"`
-	MaxDisk   int     `json:"maxdisk"`
-	MaxMem    int     `json:"maxmem"`
-	MaxSwap   int     `json:"maxswap"`
-	Mem       int     `json:"mem"`
-	Name      string  `json:"name"`
-	NetIn     int     `json:"netin"`
-	NetOut    int     `json:"netout"`
-	Status    string  `json:"status"`
-	Type      string  `json:"type"`
-	Uptime    int     `json:"uptime"`
-	VMID      string  `json:"vmid"`
+	CPU       float64     `json:"cpu"`
+	CPUs      int         `json:"cpus"`
+	Disk      int         `json:"disk"`
+	DiskRead  int         `json:"diskread"`
+	DiskWrite int         `json:"diskwrite"`
+	MaxDisk   int         `json:"maxdisk"`
+	MaxMem    int         `json:"maxmem"`
+	MaxSwap   int         `json:"maxswap"`
+	Mem       int         `json:"mem"`
+	Name      string      `json:"name"`
+	NetIn     int         `json:"netin"`
+	NetOut    int         `json:"netout"`
+	Status    string      `json:"status"`
+	Type      string      `json:"type"`
+	Uptime    int         `json:"uptime"`
+	VMID      IntOrString `json:"vmid"`
 }
 
 // GetNodeLxc makes a GET request to the /nodes/{node}/lxc endpoint
@@ -260,7 +260,7 @@ type GetNodeCertificatesInfoData struct {
 	Issuer        string   `json:"issuer"`
 	NotAfter      int      `json:"notafter"`
 	NotBefore     int      `json:"notbefore"`
-	Pem           string   `json:"pem"`
+	PEM           string   `json:"pem"`
 	PublicKeyBits int      `json:"public-key-bits"`
 	PublicKeyType string   `json:"public-key-type"`
 	San           []string `json:"san"`

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -23,9 +23,9 @@ func TestGetNodes(t *testing.T) {
 
 	want := GetNodesResponse{
 		Data: []GetNodesData{
-			{CPU: 0.0522061746389294, Disk: 5513633792, ID: "node/srv3", Level: "", MaxCPU: 8, MaxDisk: 100861726720, MaxMem: 16367738880, Mem: 14766223360, Node: "srv3", SslFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418333},
-			{CPU: 0.0220677146311971, Disk: 5727686656, ID: "node/srv1", Level: "", MaxCPU: 16, MaxDisk: 100861726720, MaxMem: 134850498560, Mem: 45189853184, Node: "srv1", SslFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418326},
-			{CPU: 0.0673548074849297, Disk: 5488590848, ID: "node/srv2", Level: "", MaxCPU: 8, MaxDisk: 100861726720, MaxMem: 16367742976, Mem: 13080690688, Node: "srv2", SslFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418322},
+			{CPU: 0.0522061746389294, Disk: 5513633792, ID: "node/srv3", Level: "", MaxCPU: 8, MaxDisk: 100861726720, MaxMem: 16367738880, Mem: 14766223360, Node: "srv3", SSLFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418333},
+			{CPU: 0.0220677146311971, Disk: 5727686656, ID: "node/srv1", Level: "", MaxCPU: 16, MaxDisk: 100861726720, MaxMem: 134850498560, Mem: 45189853184, Node: "srv1", SSLFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418326},
+			{CPU: 0.0673548074849297, Disk: 5488590848, ID: "node/srv2", Level: "", MaxCPU: 8, MaxDisk: 100861726720, MaxMem: 16367742976, Mem: 13080690688, Node: "srv2", SSLFingerprint: "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", Status: "online", Type: "node", Uptime: 418322},
 		},
 	}
 
@@ -52,15 +52,15 @@ func TestGetNode(t *testing.T) {
 		Data: GetNodeStatusData{
 			BootInfo:      BootInfo{Mode: "efi", SecureBoot: 0},
 			CPU:           0.0282238002623366,
-			CPUInfo:       CPUInfo{Cores: 50, Cpus: 200, Flags: "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap avx512ifma clflushopt intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid fsrm md_clear flush_l1d arch_capabilities", Hvm: "1", Mhz: "4886.225", Model: "99th Gen Intel(R) Core(TM) i19-9000 @ 6.50GHz", Sockets: 1, UserHz: 100},
-			CurrentKernel: CurrentKernel{Machine: "x86_64", Release: "6.5.11-8-pve", Sysname: "Linux", Version: "#1 SMP PREEMPT_DYNAMIC PMX 6.5.11-8 (2024-01-30T12:27Z)"},
+			CPUInfo:       CPUInfo{Cores: 50, CPUs: 200, Flags: "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx avx512f avx512dq rdseed adx smap avx512ifma clflushopt intel_pt avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp hwp_pkg_req vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid fsrm md_clear flush_l1d arch_capabilities", HVM: "1", MHz: "4886.225", Model: "99th Gen Intel(R) Core(TM) i19-9000 @ 6.50GHz", Sockets: 1, UserHz: 100},
+			CurrentKernel: CurrentKernel{Machine: "x86_64", Release: "6.5.11-8-pve", SysName: "Linux", Version: "#1 SMP PREEMPT_DYNAMIC PMX 6.5.11-8 (2024-01-30T12:27Z)"},
 			Idle:          0,
-			Ksm:           Ksm{Shared: 0},
+			KSM:           KSM{Shared: 0},
 			Kversion:      "Linux 6.5.11-8-pve #1 SMP PREEMPT_DYNAMIC PMX 6.5.11-8 (2024-01-30T12:27Z)",
 			LoadAvg:       []string{"0.53", "0.46", "0.43"},
 			Memory:        Memory{Free: 89574653952, Total: 134850498560, Used: 45275844608},
 			PveVersion:    "pve-manager/0.0.0/0000000000000000",
-			RootFs:        RootFs{Avail: 89962983424, Free: 95133720576, Total: 100861726720, Used: 5728006144},
+			RootFs:        RootFS{Avail: 89962983424, Free: 95133720576, Total: 100861726720, Used: 5728006144},
 			Swap:          Swap{Free: 8589930496, Total: 8589930496, Used: 0},
 			Uptime:        419090,
 			Wait:          0.00150768163794533,
@@ -68,6 +68,89 @@ func TestGetNode(t *testing.T) {
 	}
 
 	r, resp, err := client.Nodes.GetNodeStatus("srv1")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, *r)
+}
+
+func TestGetNodeLxc(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api2/json/nodes/srv1/lxc", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, fixture("nodes/get_node_lxc.json"))
+		if err != nil {
+			return
+		}
+	})
+
+	want := GetNodeLxcResponse{
+		Data: []GetNodeLxcData{
+			{
+				CPU:       0,
+				CPUs:      1,
+				Disk:      0,
+				DiskRead:  0,
+				DiskWrite: 0,
+				MaxDisk:   8589934592,
+				MaxMem:    536870912,
+				MaxSwap:   536870912,
+				Mem:       0,
+				Name:      "CT103",
+				NetIn:     0,
+				NetOut:    0,
+				Status:    "stopped",
+				Type:      "lxc",
+				Uptime:    0,
+				VMID:      IntOrString("103"),
+			},
+		},
+	}
+
+	r, resp, err := client.Nodes.GetNodeLxc("srv1")
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, want, *r)
+}
+
+func TestGetNodeQemu(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api2/json/nodes/srv1/qemu", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, fixture("nodes/get_node_qemu.json"))
+		if err != nil {
+			return
+		}
+	})
+
+	want := GetNodeQemuResponse{
+		Data: []GetNodeQemuData{
+			{
+				CPU:       0.0156071608339279,
+				CPUs:      5,
+				Disk:      0,
+				DiskRead:  0,
+				DiskWrite: 0,
+				MaxDisk:   274877906944,
+				MaxMem:    8589934592,
+				Mem:       3072665958,
+				PID:       1551,
+				Name:      "test",
+				NetIn:     294680188,
+				NetOut:    200064110,
+				Status:    "running",
+				Uptime:    28661,
+				VMID:      IntOrString("104"),
+			},
+		},
+	}
+
+	r, resp, err := client.Nodes.GetNodeQemu("srv1")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, want, *r)

--- a/testdata/nodes/get_node_lxc.json
+++ b/testdata/nodes/get_node_lxc.json
@@ -1,0 +1,23 @@
+{
+  "data":[
+    {
+      "status":"stopped",
+      "maxdisk":8589934592,
+      "maxswap":536870912,
+      "swap":0,
+      "netin":0,
+      "cpu":0,
+      "cpus":1,
+      "type":"lxc",
+      "maxmem":536870912,
+      "name":"CT103",
+      "disk":0,
+      "diskwrite":0,
+      "vmid":103,
+      "uptime":0,
+      "diskread":0,
+      "netout":0,
+      "mem":0
+    }
+  ]
+}

--- a/testdata/nodes/get_node_qemu.json
+++ b/testdata/nodes/get_node_qemu.json
@@ -1,0 +1,21 @@
+{
+  "data":[
+    {
+      "status":"running",
+      "cpus":5,
+      "netout":200064110,
+      "name":"test",
+      "vmid":104,
+      "netin":294680188,
+      "mem":3072665958,
+      "pid":1551,
+      "uptime":28661,
+      "maxdisk":274877906944,
+      "diskwrite":0,
+      "diskread":0,
+      "disk":0,
+      "cpu":0.0156071608339279,
+      "maxmem":8589934592
+    }
+  ]
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,43 @@
+package proxmox
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type testIntOrStringExample struct {
+	ID IntOrString `json:"id"`
+}
+
+// TestUnmarshalIntOrString_Positive tests the unmarshalling of valid IntOrString values.
+func TestUnmarshalIntOrString_Positive(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`{"id": 12345}`, "12345"},
+		{`{"id": "abc123"}`, "abc123"},
+	}
+
+	for _, test := range tests {
+		var example testIntOrStringExample
+		err := json.Unmarshal([]byte(test.input), &example)
+		require.NoError(t, err)
+		require.Equal(t, IntOrString(test.expected), example.ID)
+	}
+}
+
+// TestUnmarshalIntOrString_Negative tests the unmarshalling of invalid IntOrString values.
+func TestUnmarshalIntOrString_Negative(t *testing.T) {
+	tests := []string{
+		`{"id": {"nested": "object"}}`,
+		`{"id": [12345]}`,
+	}
+
+	for _, test := range tests {
+		var example testIntOrStringExample
+		err := json.Unmarshal([]byte(test), &example)
+		require.Error(t, err)
+	}
+}


### PR DESCRIPTION
When this library was written, PVE 8.1.4 was the latest release. In that release, the API field for an LXC's "VMID" returned a string. Today the latest PVE version is 8.2.4, and this same field is now an integer. In the library it would be ideal to support both versions, so I wrote a custom type that parses down into a string regardless of the type from the API.

Also added some new tests to help with testing this functionality, and bring the overall test coverage up.

There were also several struct fields that were named with inconsistent casing, which were brought in line, which is maybe less than ideal for this PR to include those but here we are.